### PR TITLE
Improved password hashing using new specialized functions

### DIFF
--- a/src/domains/Data/MimotoDataUtils.php
+++ b/src/domains/Data/MimotoDataUtils.php
@@ -442,7 +442,6 @@ class MimotoDataUtils
 
                     case MimotoEntityPropertyValueTypes::VALUETYPE_PASSWORD:
 
-                        $value = json_decode($value);
                         break;
 
                     case MimotoEntityPropertyValueTypes::VALUETYPE_JSON:
@@ -512,10 +511,7 @@ class MimotoDataUtils
                     case MimotoEntityPropertyValueTypes::VALUETYPE_PASSWORD:
 
                         // encrypt
-                        $encryptedValue = Mimoto::service('session')->createPasswordHash($value);
-
-                        // encode
-                        $value = json_encode($encryptedValue);
+                        $value = Mimoto::service('session')->createPasswordHash($value);
                         break;
 
                     case MimotoEntityPropertyValueTypes::VALUETYPE_JSON:

--- a/src/domains/Data/MimotoDataUtils.php
+++ b/src/domains/Data/MimotoDataUtils.php
@@ -510,7 +510,7 @@ class MimotoDataUtils
 
                     case MimotoEntityPropertyValueTypes::VALUETYPE_PASSWORD:
 
-                        // encrypt
+                        // hash
                         $value = Mimoto::service('session')->createPasswordHash($value);
                         break;
 

--- a/src/domains/Session/SessionService.php
+++ b/src/domains/Session/SessionService.php
@@ -76,20 +76,20 @@ class SessionService
 
     public function createPasswordHash($sPassword)
     {
-        // encrypt
-        $encryptedPassword = password_hash($sPassword, self::PASSWORD_HASH_ALGORITM, self::PASSWORD_HASH_OPTIONS);
+        // hash
+        $sHashedPassword = password_hash($sPassword, self::PASSWORD_HASH_ALGORITM, self::PASSWORD_HASH_OPTIONS);
 
         // validate
-        if (empty($encryptedPassword)) {
+        if (empty($sHashedPassword)) {
             throw new \Exception('can not properly hash password');
         }
 
         // send
-        return $encryptedPassword;
+        return $sHashedPassword;
     }
 
-    public function comparePassword($sPassword, $encryptedPassword)
+    public function comparePassword($sPassword, $sHashedPassword)
     {
-        return password_verify($sPassword, $encryptedPassword);
+        return password_verify($sPassword, $sHashedPassword);
     }
 }

--- a/src/userinterface/MimotoCMS/DashboardController.php
+++ b/src/userinterface/MimotoCMS/DashboardController.php
@@ -35,7 +35,7 @@ class DashboardController
             if (count($aUsers) == 0)
             {
                 // add temp password
-                $sPassword = json_encode(Mimoto::service('session')->createPasswordHash('welcome'));
+                $sPassword = Mimoto::service('session')->createPasswordHash('welcome');
 
 
                 Mimoto::output('Installing Mimoto (step 2 / 2)', "Add your first user (with owner permissions)<br>

--- a/src/userinterface/MimotoCMS/SessionController.php
+++ b/src/userinterface/MimotoCMS/SessionController.php
@@ -114,6 +114,8 @@ class SessionController
 
                 if (Mimoto::service('session')->comparePassword($sPassword, $sHashedPassword))
                 {
+                    // #todo check for password upgrades using password_needs_rehash()
+
                     // compose
                     $user = (object) array(
                         'id' => $eUser->getId(),

--- a/src/userinterface/MimotoCMS/SessionController.php
+++ b/src/userinterface/MimotoCMS/SessionController.php
@@ -110,9 +110,9 @@ class SessionController
             if ($sUsername == $eUser->getValue('email'))
             {
                 // read
-                $encryptedPassword = $eUser->getValue('password');
+                $sHashedPassword = $eUser->getValue('password');
 
-                if (Mimoto::service('session')->comparePassword($sPassword, $encryptedPassword))
+                if (Mimoto::service('session')->comparePassword($sPassword, $sHashedPassword))
                 {
                     // compose
                     $user = (object) array(


### PR DESCRIPTION
PHP has specialized functions for password hashing, meant to simplify the interface but also to be more secure, partly because there's less room for implementation errors.

See also http://php.net/manual/en/book.password.php

Note I didn't check the database storage. This method will output something like `$2y$11$nsqRkXbim6GsNd5c976qFuYVhHh3vGNfwz8zvulg3UwudQThEqowK` and be 60 chars length with the current hashing algorithm defaults. Best is to use a `varchar(255)` or alike.